### PR TITLE
Add Role Initialization System

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,24 @@ A secure blockchain-based tool for managing gaming communities with role-based a
 - Community token rewards
 - Member verification
 
+## Default Roles
+The contract initializes with three default roles:
+
+1. Admin
+   - Can invite new members
+   - Can verify members
+   - Can moderate and assign reputation
+
+2. Moderator
+   - Can invite new members
+   - Can verify members
+   - Can moderate and assign reputation
+
+3. Member
+   - Basic access to community features
+   - No special permissions
+
+The contract deployer is automatically assigned the admin role.
+
 ## Usage
 [Include usage instructions and examples]

--- a/contracts/game-guard.clar
+++ b/contracts/game-guard.clar
@@ -25,6 +25,41 @@
   }
 )
 
+;; Initialize default roles
+(define-private (initialize-roles)
+  (begin
+    (map-set community-roles "admin"
+      {
+        can-invite: true,
+        can-verify: true, 
+        can-moderate: true
+      }
+    )
+    (map-set community-roles "moderator"
+      {
+        can-invite: true,
+        can-verify: true,
+        can-moderate: true  
+      }
+    )
+    (map-set community-roles "member"
+      {
+        can-invite: false,
+        can-verify: false,
+        can-moderate: false
+      }
+    )
+    (map-set members contract-owner
+      {
+        role: "admin",
+        reputation: u100,
+        join-height: block-height,
+        verified: true
+      }
+    )
+  )
+)
+
 ;; Public functions
 (define-public (join-community)
   (let ((sender tx-sender))
@@ -70,7 +105,7 @@
   )
 )
 
-;; Read only functions
+;; Read only functions 
 (define-read-only (get-member-data (member principal))
   (map-get? members member)
 )
@@ -86,3 +121,5 @@
     (get can-moderate (unwrap-panic (map-get? community-roles (get role role-data))))
   )
 )
+
+(initialize-roles)

--- a/tests/game-guard_test.ts
+++ b/tests/game-guard_test.ts
@@ -39,3 +39,23 @@ Clarinet.test({
     block.receipts[1].result.expectOk().expectBool(true);
   },
 });
+
+Clarinet.test({
+  name: "Verify default roles are initialized correctly",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const deployer = accounts.get("deployer")!;
+    
+    let memberData = chain.callReadOnlyFn(
+      "game-guard",
+      "get-member-data",
+      [types.principal(deployer.address)],
+      deployer.address
+    );
+
+    memberData.result.expectSome().expectTuple({
+      "role": types.ascii("admin"),
+      "reputation": types.uint(100),
+      "verified": types.bool(true)
+    });
+  },
+});


### PR DESCRIPTION
This PR enhances the GameGuard contract by adding a proper role initialization system. The main changes include:

1. Added an `initialize-roles` private function that sets up default community roles:
   - Admin role with full permissions
   - Moderator role with moderation permissions
   - Basic member role with no special permissions

2. Contract deployer is automatically assigned as an admin during initialization

3. Added test coverage for role initialization

4. Updated documentation to reflect the default role system

These changes improve the contract by:
- Ensuring consistent role setup across deployments
- Providing immediate admin access to contract deployer
- Making the permission system more maintainable
- Reducing potential for role configuration errors

No breaking changes were introduced, and existing functionality remains unchanged.